### PR TITLE
Added ability to pass region down to knox client

### DIFF
--- a/src/lib/winston-s3.coffee
+++ b/src/lib/winston-s3.coffee
@@ -22,6 +22,7 @@ class winston.transports.S3 extends winston.Transport
       key: opts.key
       secret: opts.secret
       bucket: opts.bucket
+      region: opts.region
     }
     @bufferSize = 0
     @maxSize = opts.maxSize || 20 * 1024 * 1024


### PR DESCRIPTION
Hey we are using your s3 transport but we are in the UK so we needed to manually specify the region, its an issue we've had with knox before 
